### PR TITLE
Updates package dependencies and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is recommended to run the mongoDB database and the web interface inside docke
 
 To start the containers run:
 ```
-docker-compose up
+docker compose up
 ```
 
 ### Gadget Aggregation
@@ -51,7 +51,7 @@ Please refer to the `Taskfile.yml` for included evaluation scripts.
 
 ### Web Interface
 
-The easiest way to run the web interface is using the included `Dockerfile` together with `docker-compose`.
+The easiest way to run the web interface is using the included `Dockerfile` together with `docker compose`.
 
 Otherwise, you can setup the dependencies with:
 ```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,7 +77,7 @@ tasks:
   clear-db:
     desc: drop kasper database
     cmds:
-      - docker exec -i $(docker-compose ps -q db) mongo {{.MONGO_URI}}/kasper --authenticationDatabase admin --eval "db.dropDatabase()"
+      - docker exec -i $(docker compose ps -q db) mongo {{.MONGO_URI}}/kasper --authenticationDatabase admin --eval "db.dropDatabase()"
 
   import-db:
     desc: import mongodb into docker container
@@ -87,23 +87,23 @@ tasks:
       RUNDIR_OBJ: "{ rundir: \'{{.RUNDIR}}\' }"
     cmds:
       - task: clear-db
-      - docker cp {{.DB_DUMP}} $(docker-compose ps -q db):/data/db.dump
-      - docker exec -i $(docker-compose ps -q db) mongorestore --uri={{.MONGO_URI}} --archive=/data/db.dump
-      - docker exec -i $(docker-compose ps -q db) rm /data/db.dump
-      - docker exec -i $(docker-compose ps -q db) mongo {{.MONGO_URI}}/kasper --authenticationDatabase admin --eval "db.rundir.insertOne({{.RUNDIR_OBJ}})" --quiet
+      - docker cp {{.DB_DUMP}} $(docker compose ps -q db):/data/db.dump
+      - docker exec -i $(docker compose ps -q db) mongorestore --uri={{.MONGO_URI}} --archive=/data/db.dump
+      - docker exec -i $(docker compose ps -q db) rm /data/db.dump
+      - docker exec -i $(docker compose ps -q db) mongo {{.MONGO_URI}}/kasper --authenticationDatabase admin --eval "db.rundir.insertOne({{.RUNDIR_OBJ}})" --quiet
 
   export-db-generic:
     desc: export mongodb from docker container
     cmds:
-      - docker exec -i $(docker-compose ps -q db) mongodump --uri={{.MONGO_URI}} --authenticationDatabase admin --db kasper --excludeCollection rundir --archive=/data/db.dump
-      - docker cp $(docker-compose ps -q db):/data/db.dump {{.DB_DUMP}}
-      - docker exec -i $(docker-compose ps -q db) rm /data/db.dump
+      - docker exec -i $(docker compose ps -q db) mongodump --uri={{.MONGO_URI}} --authenticationDatabase admin --db kasper --excludeCollection rundir --archive=/data/db.dump
+      - docker cp $(docker compose ps -q db):/data/db.dump {{.DB_DUMP}}
+      - docker exec -i $(docker compose ps -q db) rm /data/db.dump
 
   export-db:
     desc: export mongodb from docker container into rundir
     vars:
       RUNDIR:
-        sh: docker exec -i $(docker-compose ps -q db) mongosh {{.MONGO_URI}}/kasper --authenticationDatabase admin --eval "db.rundir.findOne({}).rundir" --quiet
+        sh: docker exec -i $(docker compose ps -q db) mongosh {{.MONGO_URI}}/kasper --authenticationDatabase admin --eval "db.rundir.findOne({}).rundir" --quiet
     cmds:
       - task: export-db-generic
         vars: {DB_DUMP: '{{.RUNDIR}}/db.dump'}

--- a/web-interface/backend/requirements.txt
+++ b/web-interface/backend/requirements.txt
@@ -3,3 +3,4 @@ Flask-Login==0.5.0
 Flask-WTF==1.0.0
 waitress==2.0.0
 pymongo==4.0.1
+Werkzeug~=2.0.0


### PR DESCRIPTION
Pins a python package a particular version to fix "ImportError: cannot import name 'safe_str_cmp' from 'werkzeug.security'".

Docker-compose has become 'docker compose' in the newer versions.
